### PR TITLE
Don't send name when player choice is selected

### DIFF
--- a/src/components/Join.js
+++ b/src/components/Join.js
@@ -49,7 +49,7 @@ function Join(props) {
       console.error(`Not sending choice, no connections for roomId ${roomId}`);
       return;
     }
-    const send = (c) => c.send({ name: name, answer: choice, question: question.question });
+    const send = (c) => c.send({ answer: choice, question: question.question });
     peer.connections[roomId].forEach(send);
   };
 


### PR DESCRIPTION
The player's name is already associated with the connection on the host side, and when the name has an emoji, the PeerJS serialization messes with the unicode emoji character, resulting in the host receiving `{"110": 115, "119": 101, "name": "ߤ㶡"}`, which isn't what was sent by the player. This is resulting in the answer being marked as false for the player, even when they answer correctly.

Fixes #14 